### PR TITLE
Removed ensure param from concat::fragment declaration

### DIFF
--- a/manifests/cpan/module.pp
+++ b/manifests/cpan/module.pp
@@ -26,7 +26,6 @@ define perlbrew::cpan::module (
   include perlbrew::cpan::install
 
   concat::fragment {"perl_module_${title}"  :
-    ensure  => present,
     target  => "${perlbrew::cpan::install::cpanfile_dir}/${perlbrew::cpan::install::cpanfile_name}",
     content => template('perlbrew/cpanfile_entry.erb'),
   }


### PR DESCRIPTION
`Concat::Fragment` doesn't have an `ensure` parameter (at least not in later versions of the module).  Declaring `ensure => present` breaks compatibility with later versions of the module, so I've removed it.  

I didn't see any other instances where `Concat::Fragment` declarations included the `ensure` parameter, so I only fixed the one.

Let me know if you have any questions.